### PR TITLE
Rename "shrink" flex action to "change duration"

### DIFF
--- a/docs/adr/0002-session-is-adapter-not-domain.md
+++ b/docs/adr/0002-session-is-adapter-not-domain.md
@@ -2,7 +2,7 @@
 
 An unfinished Session is a glossary/UI fact. It is not a type in `tomorrow/domain.py`. `Draft`, `Anchor`, `Flex`, and `finalize_plan` stay the finalization seam; ids never land on those types.
 
-The adapter module `tomorrow/session.py` owns gitignored `data/session.json` (load/save, mint opaque ids, apply add/edit/Drop/Place/Shrink/Reset/Template/promote-Draft, unpack into domain types, call `finalize_plan`). HTTP only routes and serializes. Construction rules live in that module, not in the domain and not in `do_POST` branches.
+The adapter module `tomorrow/session.py` owns gitignored `data/session.json` (load/save, mint opaque ids, apply add/edit/Drop/Place/Change-Duration/Reset/Template/promote-Draft, unpack into domain types, call `finalize_plan`). HTTP only routes and serializes. Construction rules live in that module, not in the domain and not in `do_POST` branches.
 
 **Why:** keeping the Python domain as the core means honesty checks (`finalize_plan`), not a second mutable aggregate that would shadow `FinalizedPlan`. A Session struct or Session operations in `domain.py` would expand that seam; stuffing the same rules into the HTTP handler would make the adapter fat. The file shape is the Session; Gaps and blockers stay derived.
 

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -8,6 +8,5 @@
 - Automatic free time blocks for the empty blocks
 - Connection to icloud calendar and including reminders suggetsions for adding
 - When I want to add sleep time past midnight, it weirdly stretches and doesn't work
-- Rename "shrink" to change duration (it can go both ways)
 - Templates for flex activities (i. e. deep work - 90min, morning routine - 70min, etc.)
 - Rendering the plans in a better format - I'm thinking maybe pdf would be better? I'm open to recommendations, maybe we should stay with this.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -452,7 +452,7 @@ def test_edit_anchor_and_bounds_over_http(tmp_path: Path) -> None:
     assert removed["anchors"] == []
 
 
-def test_add_place_shrink_and_drop_flex_over_http(tmp_path: Path) -> None:
+def test_add_place_change_duration_and_drop_flex_over_http(tmp_path: Path) -> None:
     _write_defaults(tmp_path)
     server, thread = _start_server(tmp_path)
     try:
@@ -467,9 +467,9 @@ def test_add_place_shrink_and_drop_flex_over_http(tmp_path: Path) -> None:
             "/api/place",
             payload={"id": item_id, "start": "22:00"},
         )
-        shrink_status, shrunk_body = _http(
+        change_duration_status, changed_duration_body = _http(
             "POST",
-            "/api/shrink",
+            "/api/change-duration",
             payload={"id": item_id, "duration_minutes": 45},
         )
         drop_status, dropped_body = _http(
@@ -482,7 +482,7 @@ def test_add_place_shrink_and_drop_flex_over_http(tmp_path: Path) -> None:
 
     added = json.loads(added_body)
     placed = json.loads(placed_body)
-    shrunk = json.loads(shrunk_body)
+    changed_duration = json.loads(changed_duration_body)
     dropped = json.loads(dropped_body)
     flushed = json.loads((tmp_path / "data" / "session.json").read_text(encoding="utf-8"))
     assert add_status == 200
@@ -492,9 +492,9 @@ def test_add_place_shrink_and_drop_flex_over_http(tmp_path: Path) -> None:
     assert place_status == 200
     assert placed["flexes"][0]["start"] == "22:00"
     assert "undo" not in placed
-    assert shrink_status == 200
-    assert shrunk["flexes"][0]["duration_minutes"] == 45
-    assert "undo" not in shrunk
+    assert change_duration_status == 200
+    assert changed_duration["flexes"][0]["duration_minutes"] == 45
+    assert "undo" not in changed_duration
     assert drop_status == 200
     assert dropped["flexes"] == []
     assert "undo" not in dropped

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -177,7 +177,7 @@ def test_snap_to_gap_start_produces_a_valid_placement() -> None:
 def test_change_duration_then_placed_flex_fits() -> None:
     standup = Anchor(name="Standup", start=time(7, 0), duration=timedelta(minutes=15))
     lunch = Anchor(name="Lunch", start=time(12, 0), duration=timedelta(minutes=60))
-    shrunk = Flex(
+    resized = Flex(
         name="Deep work",
         duration=timedelta(minutes=60),
         start=time(7, 15),
@@ -187,7 +187,7 @@ def test_change_duration_then_placed_flex_fits() -> None:
         bounds=BOUNDS,
         drafts=[],
         anchors=[standup, lunch],
-        flexes=[shrunk],
+        flexes=[resized],
     )
 
     assert result.ok

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -174,7 +174,7 @@ def test_snap_to_gap_start_produces_a_valid_placement() -> None:
     )
 
 
-def test_shrink_then_placed_flex_fits() -> None:
+def test_change_duration_then_placed_flex_fits() -> None:
     standup = Anchor(name="Standup", start=time(7, 0), duration=timedelta(minutes=15))
     lunch = Anchor(name="Lunch", start=time(12, 0), duration=timedelta(minutes=60))
     shrunk = Flex(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -35,7 +35,7 @@ from tomorrow.session import (
     promote_draft,
     reset_session,
     session_view,
-    shrink_flex,
+    change_flex_duration,
     submit_session,
     redo_session,
     undo_session,
@@ -832,7 +832,7 @@ def test_placed_flex_that_does_not_fit_is_a_live_blocker(tmp_path: Path) -> None
     assert view["blockers"]
 
 
-def test_shrinking_flex_flushes_and_can_clear_a_does_not_fit_blocker(
+def test_changing_duration_flushes_and_can_clear_a_does_not_fit_blocker(
     tmp_path: Path,
 ) -> None:
     _write_defaults(tmp_path)
@@ -841,7 +841,7 @@ def test_shrinking_flex_flushes_and_can_clear_a_does_not_fit_blocker(
     item_id = added["flexes"][0]["id"]
     place_flex(tmp_path, item_id=item_id, start="22:00", now=now)
 
-    view = shrink_flex(tmp_path, item_id=item_id, duration_minutes=45, now=now)
+    view = change_flex_duration(tmp_path, item_id=item_id, duration_minutes=45, now=now)
     document = json.loads(
         (tmp_path / "data" / "session.json").read_text(encoding="utf-8")
     )
@@ -852,13 +852,13 @@ def test_shrinking_flex_flushes_and_can_clear_a_does_not_fit_blocker(
     assert view["blockers"] == []
 
 
-def test_shrinking_unplaced_flex_leaves_it_unplaced(tmp_path: Path) -> None:
+def test_changing_duration_unplaced_flex_leaves_it_unplaced(tmp_path: Path) -> None:
     _write_defaults(tmp_path)
     now = datetime(2026, 8, 10, 22, 0)
     added = add_flex(tmp_path, name="Walk", duration_minutes=45, now=now)
     item_id = added["flexes"][0]["id"]
 
-    view = shrink_flex(tmp_path, item_id=item_id, duration_minutes=20, now=now)
+    view = change_flex_duration(tmp_path, item_id=item_id, duration_minutes=20, now=now)
     document = json.loads(
         (tmp_path / "data" / "session.json").read_text(encoding="utf-8")
     )
@@ -1776,7 +1776,7 @@ def test_undo_of_template_apply_is_one_step(tmp_path: Path) -> None:
     assert view["can_redo"] is True
 
 
-def test_undo_restores_edits_drop_place_shrink_and_promote(
+def test_undo_restores_edits_drop_place_change_duration_and_promote(
     tmp_path: Path,
 ) -> None:
     _write_defaults(tmp_path)
@@ -1800,7 +1800,7 @@ def test_undo_restores_edits_drop_place_shrink_and_promote(
     undo_session(tmp_path, now=now)
     assert session_view(tmp_path, now=now)["flexes"][0]["start"] is None
 
-    shrink_flex(tmp_path, item_id=flex_id, duration_minutes=10, now=now)
+    change_flex_duration(tmp_path, item_id=flex_id, duration_minutes=10, now=now)
     undo_session(tmp_path, now=now)
     assert session_view(tmp_path, now=now)["flexes"][0]["duration_minutes"] == 30
 

--- a/tomorrow/session.py
+++ b/tomorrow/session.py
@@ -344,7 +344,7 @@ def place_flex(
     return _commit(repo_root, document, mutate, now=now, opener=opener)
 
 
-def shrink_flex(
+def change_flex_duration(
     repo_root: Path,
     *,
     item_id: str,
@@ -1022,9 +1022,9 @@ class SessionHandler(BaseHTTPRequestHandler):
             )
             self._send_json(200, view)
             return
-        if path == "/api/shrink":
+        if path == "/api/change-duration":
             payload = self._read_json()
-            view = shrink_flex(
+            view = change_flex_duration(
                 self.server.repo_root,
                 item_id=payload["id"],
                 duration_minutes=int(payload["duration_minutes"]),

--- a/tomorrow/static/session.html
+++ b/tomorrow/static/session.html
@@ -327,7 +327,7 @@
   </div>
 
   <div class="tray empty" id="tray">
-    <div class="tray-label">Unplaced Flex — Place / Shrink / Drop any time</div>
+    <div class="tray-label">Unplaced Flex — Place / Change Duration / Drop any time</div>
     <div>No unplaced Flex.</div>
   </div>
 
@@ -510,13 +510,13 @@
       if (!unplaced.length) {
         tray.classList.add("empty");
         tray.innerHTML =
-          '<div class="tray-label">Unplaced Flex — Place / Shrink / Drop any time</div>' +
+          '<div class="tray-label">Unplaced Flex — Place / Change Duration / Drop any time</div>' +
           "<div>No unplaced Flex.</div>";
         return;
       }
       tray.classList.remove("empty");
       tray.innerHTML =
-        '<div class="tray-label">Unplaced Flex — Place / Shrink / Drop any time</div>' +
+        '<div class="tray-label">Unplaced Flex — Place / Change Duration / Drop any time</div>' +
         '<div class="tray-chips">' + unplaced.map(item =>
           '<div class="flex-chip' + (armedFlexId === item.id ? " armed" : "") +
           '" data-arm="' + esc(item.id) + '">' +
@@ -525,7 +525,7 @@
           '<div class="ops">' +
           '<button type="button" data-edit-flex="' + esc(item.id) + '">Edit</button>' +
           '<button type="button" data-place="' + esc(item.id) + '">Place</button>' +
-          '<button type="button" data-shrink="' + esc(item.id) + '">Shrink</button>' +
+          '<button type="button" data-change-duration="' + esc(item.id) + '">Change Duration</button>' +
           '<button type="button" data-drop="' + esc(item.id) + '">Drop</button>' +
           "</div></div>"
         ).join("") + "</div>";
@@ -743,13 +743,13 @@
       );
     }
 
-    function sheetShrink(item) {
+    function sheetChangeDuration(item) {
       openSheet(
-        "<h2>Shrink Flex · " + esc(item.name) + "</h2>" +
-        '<form id="shrink-flex" data-id="' + esc(item.id) + '">' +
+        "<h2>Change Duration · " + esc(item.name) + "</h2>" +
+        '<form id="change-duration-flex" data-id="' + esc(item.id) + '">' +
         '<label>New duration (min) <input name="duration_minutes" type="number" min="1" required value="' +
         esc(item.duration_minutes) + '"></label>' +
-        '<div class="actions"><button class="primary" type="submit">Shrink</button>' +
+        '<div class="actions"><button class="primary" type="submit">Change Duration</button>' +
         '<button type="button" class="ghost" data-close>Cancel</button></div></form>'
       );
     }
@@ -782,7 +782,7 @@
         checklistField(item.checklist) +
         '<div class="actions"><button class="primary" type="submit">Update</button>' +
         '<button type="button" class="ghost" data-place="' + esc(item.id) + '">Place</button>' +
-        '<button type="button" class="ghost" data-shrink="' + esc(item.id) + '">Shrink</button>' +
+        '<button type="button" class="ghost" data-change-duration="' + esc(item.id) + '">Change Duration</button>' +
         '<button type="button" class="ghost" data-close>Cancel</button>' +
         '<button type="button" class="danger" data-drop="' + esc(item.id) + '">Drop</button></div></form>'
       );
@@ -912,11 +912,11 @@
         if (item) sheetPlace(item);
         return;
       }
-      const shrinkId = event.target.dataset.shrink;
-      if (shrinkId) {
+      const changeDurationId = event.target.dataset.changeDuration;
+      if (changeDurationId) {
         event.stopPropagation();
-        const item = findFlex(shrinkId);
-        if (item) sheetShrink(item);
+        const item = findFlex(changeDurationId);
+        if (item) sheetChangeDuration(item);
         return;
       }
       const editId = event.target.dataset.editFlex;
@@ -970,11 +970,11 @@
         if (item) sheetPlace(item);
         return;
       }
-      const shrinkId = event.target.dataset.shrink;
-      if (shrinkId) {
+      const changeDurationId = event.target.dataset.changeDuration;
+      if (changeDurationId) {
         event.preventDefault();
-        const item = findFlex(shrinkId);
-        if (item) sheetShrink(item);
+        const item = findFlex(changeDurationId);
+        if (item) sheetChangeDuration(item);
       }
     });
 
@@ -1035,8 +1035,8 @@
         await placeFlexAt(form.dataset.id, clockValue(form.start));
         return;
       }
-      if (form.id === "shrink-flex") {
-        await mutate("/api/shrink", {
+      if (form.id === "change-duration-flex") {
+        await mutate("/api/change-duration", {
           id: form.dataset.id,
           duration_minutes: Number(form.duration_minutes.value)
         });


### PR DESCRIPTION
## Summary
- Renamed the backend `shrink_flex` function to `change_flex_duration` and its HTTP route from `/api/shrink` to `/api/change-duration`.
- Updated all frontend labels, form ids, data attributes, and handler names in `tomorrow/static/session.html` from "Shrink" to "Change Duration".
- Updated tests and the affected ADR reference to match.

Closes #35

## Test plan
- [x] `pytest` (184 passed)