### PR TITLE
Fix: sleep past midnight breaks day bounds and Anchor placement

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,7 +52,7 @@ A Plan item with a known duration but no fixed start; it must be placed into a f
 _Avoid_: Soft task, duration task, floating block
 
 **Day bounds**:
-The wake time and sleep time that define the Plan's temporal envelope for that day. Pre-filled from Defaults when a Session starts; editable on the Session. Changing them does not rewrite Defaults.
+The wake time and sleep time that define the Plan's temporal envelope for that day. Pre-filled from Defaults when a Session starts; editable on the Session. Changing them does not rewrite Defaults. Sleep at or before wake (clock-time) is a same-day-name for a time that falls after midnight: the envelope always runs wake → wake+24h, never wake → midnight. Wake equal to sleep is invalid (zero-length day) and blocks Submit. An Anchor may likewise fall after midnight; its position is judged by the same wake-relative offset, not by raw clock time.
 _Avoid_: Availability, working hours, confirmed bounds
 
 **Gap**:

--- a/docs/adr/0003-clock-times-as-minutes-since-wake.md
+++ b/docs/adr/0003-clock-times-as-minutes-since-wake.md
@@ -1,0 +1,7 @@
+# Clock times are offsets from wake, not minutes-since-midnight
+
+Day bounds, Anchors, Flex, and Gaps all resolve to minutes-since-wake — `(clock - wake) mod 1440` — everywhere ordering, overlap, or bounds-checking happens, in both `tomorrow/domain.py`/`tomorrow/plan.py` and the `session.html` JS. Midnight-crossing is not a separate code path: sleep at or before wake, or an Anchor with an early clock time, both land past the wake→wake+24h span naturally once expressed as an offset. Wake equal to sleep collapses the envelope to zero minutes and is rejected the same way other bounds problems are — as a finalize-time blocker, not eager validation in `edit_bounds`.
+
+**Why:** the alternative (an explicit "this time is past midnight" flag per bound/Anchor) pushes a bookkeeping burden onto the user for something inferable from the data itself, and would need to be threaded through every place a clock time is entered or edited. Minutes-since-wake makes midnight-crossing a property of the arithmetic, not a case every call site has to remember to check.
+
+**Considered:** an explicit next-day toggle on sleep/Anchor times; keeping `minutes_since_midnight` and special-casing comparisons where wraparound is possible.

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -7,6 +7,7 @@ from tomorrow.domain import (
     Anchor,
     AnchorOutOfBoundsBlocker,
     AnchorOverlapBlocker,
+    DegenerateDayBoundsBlocker,
     Draft,
     DraftUnfinishedBlocker,
     Flex,
@@ -16,12 +17,14 @@ from tomorrow.domain import (
     compute_gaps,
     finalize_plan,
     minutes_between,
+    minutes_since_wake,
     parse_clock,
     snap_flex_to_gap_start,
     validate_flex_placement,
 )
 
 BOUNDS = DayBounds(wake="06:30", sleep="23:00")
+OVERNIGHT_BOUNDS = DayBounds(wake="07:00", sleep="01:00")
 
 
 def test_parse_clock_reads_hh_mm() -> None:
@@ -170,7 +173,7 @@ def test_snap_to_gap_start_produces_a_valid_placement() -> None:
     placed = snap_flex_to_gap_start(sauna, gaps[1])
     assert placed.start == time(7, 15)
     assert validate_flex_placement(
-        placed, gaps=gaps, anchors=[standup], other_flexes=[]
+        placed, gaps=gaps, anchors=[standup], other_flexes=[], wake=time(6, 30)
     )
 
 
@@ -201,3 +204,71 @@ def test_finalize_plan_with_no_flexes_is_trivially_finished() -> None:
     assert result.ok
     assert result.plan is not None
     assert result.plan.flexes == ()
+
+
+def test_minutes_since_wake_wraps_past_midnight() -> None:
+    assert minutes_since_wake(time(0, 30), wake=time(7, 0)) == 17 * 60 + 30
+    assert minutes_since_wake(time(7, 0), wake=time(7, 0)) == 0
+    assert minutes_since_wake(time(6, 59), wake=time(7, 0)) == 1439
+
+
+def test_compute_gaps_handles_sleep_past_midnight() -> None:
+    dinner = Anchor(name="Dinner", start=time(19, 0), duration=timedelta(minutes=60))
+
+    gaps = compute_gaps(bounds=OVERNIGHT_BOUNDS, anchors=[dinner])
+
+    assert gaps == (
+        Gap(start=time(7, 0), end=time(19, 0)),
+        Gap(start=time(20, 0), end=time(1, 0)),
+    )
+
+
+def test_finalize_plan_places_flex_in_gap_after_midnight() -> None:
+    dinner = Anchor(name="Dinner", start=time(19, 0), duration=timedelta(minutes=60))
+    late_read = Flex(name="Read", duration=timedelta(minutes=30), start=time(0, 15))
+
+    result = finalize_plan(
+        bounds=OVERNIGHT_BOUNDS, drafts=[], anchors=[dinner], flexes=[late_read]
+    )
+
+    assert result.ok
+    assert result.plan is not None
+    assert result.plan.flexes == (late_read,)
+
+
+def test_finalize_plan_accepts_anchor_after_midnight_within_bounds() -> None:
+    late_snack = Anchor(name="Snack", start=time(0, 30), duration=timedelta(minutes=15))
+
+    result = finalize_plan(bounds=OVERNIGHT_BOUNDS, drafts=[], anchors=[late_snack])
+
+    assert result.ok
+
+
+def test_finalize_plan_flags_anchor_that_looks_early_but_is_out_of_bounds() -> None:
+    # 05:00 looks "early" by raw clock time, but with wake=07:00/sleep=01:00
+    # it falls after sleep once expressed as a wake-relative offset.
+    too_early = Anchor(name="Too early", start=time(5, 0), duration=timedelta(minutes=30))
+
+    result = finalize_plan(bounds=OVERNIGHT_BOUNDS, drafts=[], anchors=[too_early])
+
+    assert not result.ok
+    assert result.blockers == (AnchorOutOfBoundsBlocker(anchor=too_early),)
+
+
+def test_finalize_plan_catches_overlap_between_two_anchors_after_midnight() -> None:
+    first = Anchor(name="First", start=time(0, 0), duration=timedelta(minutes=45))
+    second = Anchor(name="Second", start=time(0, 30), duration=timedelta(minutes=30))
+
+    result = finalize_plan(bounds=OVERNIGHT_BOUNDS, drafts=[], anchors=[first, second])
+
+    assert not result.ok
+    assert result.blockers == (AnchorOverlapBlocker(first=first, second=second),)
+
+
+def test_finalize_plan_blocks_when_wake_equals_sleep() -> None:
+    degenerate_bounds = DayBounds(wake="07:00", sleep="07:00")
+
+    result = finalize_plan(bounds=degenerate_bounds, drafts=[], anchors=[])
+
+    assert not result.ok
+    assert result.blockers == (DegenerateDayBoundsBlocker(bounds=degenerate_bounds),)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -128,6 +128,20 @@ def test_render_plan_shows_flex_gaps_and_complete_timeline() -> None:
     assert "07:45" in html
 
 
+def test_render_plan_marks_anchor_and_sleep_after_midnight() -> None:
+    late_snack = Anchor(name="Snack", start=time(0, 30), duration=timedelta(minutes=15))
+
+    html = render_plan(
+        plan_date=date(2026, 8, 11),
+        bounds=DayBounds(wake="07:00", sleep="01:00"),
+        anchors=[late_snack],
+    )
+
+    assert "00:30 +1" in html
+    assert "01:00 +1 sleep ↓" in html
+    assert "Sleep 01:00 +1" in html
+
+
 def test_render_plan_shows_prep_accordion_for_attached_checklists() -> None:
     gym = Anchor(
         name="Gym",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -683,6 +683,57 @@ def test_gaps_update_when_bounds_change(tmp_path: Path) -> None:
     ]
 
 
+def test_gaps_span_midnight_when_sleep_is_before_wake(tmp_path: Path) -> None:
+    _write_defaults(tmp_path)
+    now = datetime(2026, 8, 10, 22, 0)
+    edit_bounds(tmp_path, wake="07:00", sleep="01:00", now=now)
+
+    view = add_anchor(
+        tmp_path, name="Dinner", start="19:00", duration_minutes=60, now=now
+    )
+
+    assert view["bounds"] == {
+        "wake": "07:00",
+        "sleep": "01:00",
+        "sleep_is_next_day": True,
+    }
+    assert view["gaps"] == [
+        {"start": "07:00", "end": "19:00", "duration_minutes": 720},
+        {
+            "start": "20:00",
+            "end": "01:00",
+            "duration_minutes": 300,
+            "end_is_next_day": True,
+        },
+    ]
+
+
+def test_flex_placed_in_gap_after_midnight_is_not_a_blocker(tmp_path: Path) -> None:
+    _write_defaults(tmp_path)
+    now = datetime(2026, 8, 10, 22, 0)
+    edit_bounds(tmp_path, wake="07:00", sleep="01:00", now=now)
+    added = add_flex(tmp_path, name="Read", duration_minutes=30, now=now)
+    flex_id = added["flexes"][0]["id"]
+
+    view = place_flex(tmp_path, item_id=flex_id, start="00:15", now=now)
+
+    assert view["blockers"] == []
+
+
+def test_submit_blocks_when_wake_equals_sleep(tmp_path: Path) -> None:
+    _write_defaults(tmp_path)
+    now = datetime(2026, 8, 10, 22, 0)
+    edit_bounds(tmp_path, wake="07:00", sleep="07:00", now=now)
+
+    view = edit_bounds(tmp_path, sleep="07:00", now=now)
+
+    assert view["blockers"] == [
+        "Wake and sleep are both 07:00, leaving a zero-length day."
+    ]
+    with pytest.raises(PlanBlockedError):
+        submit_session(tmp_path, now=now)
+
+
 def test_anchor_outside_new_bounds_is_a_live_blocker(tmp_path: Path) -> None:
     _write_defaults(tmp_path)
     now = datetime(2026, 8, 10, 22, 0)

--- a/tomorrow/domain.py
+++ b/tomorrow/domain.py
@@ -114,12 +114,20 @@ class FlexDoesNotFitBlocker:
     flex: Flex
 
 
+@dataclass(frozen=True)
+class DegenerateDayBoundsBlocker:
+    """Wake equals sleep, collapsing the day's envelope to zero minutes."""
+
+    bounds: DayBounds
+
+
 Blocker = Union[
     DraftUnfinishedBlocker,
     AnchorOverlapBlocker,
     AnchorOutOfBoundsBlocker,
     FlexUnplacedBlocker,
     FlexDoesNotFitBlocker,
+    DegenerateDayBoundsBlocker,
 ]
 
 
@@ -161,6 +169,23 @@ def minutes_since_midnight(value: time) -> int:
     return value.hour * 60 + value.minute
 
 
+def minutes_since_wake(value: time, *, wake: time) -> int:
+    """Offset in minutes from wake, wrapping past midnight into wake+24h.
+
+    This is the basis for all ordering, overlap, and bounds-checking:
+    a clock time earlier than wake is understood as "tomorrow, early
+    morning" rather than "today, very early" — see docs/adr/0003.
+    """
+
+    return (minutes_since_midnight(value) - minutes_since_midnight(wake)) % 1440
+
+
+def is_next_day(value: time, *, wake: time) -> bool:
+    """Whether `value` falls on the calendar day after `wake`, wake-relative."""
+
+    return minutes_since_midnight(value) < minutes_since_midnight(wake)
+
+
 def minutes_between(start: time, end: time) -> int:
     """Whole minutes from start to end. Raises if end is not after start."""
 
@@ -168,10 +193,6 @@ def minutes_between(start: time, end: time) -> int:
     if duration <= 0:
         raise ValueError("End time must be after start time.")
     return duration
-
-
-def _bound_minutes(value: str) -> int:
-    return minutes_since_midnight(parse_clock(value))
 
 
 def _occupied_minutes(duration: timedelta) -> int:
@@ -187,24 +208,24 @@ def compute_gaps(*, bounds: DayBounds, anchors: Sequence[Anchor]) -> tuple[Gap, 
 
     wake = parse_clock(bounds.wake)
     sleep = parse_clock(bounds.sleep)
-    ordered = sorted(anchors, key=lambda anchor: minutes_since_midnight(anchor.start))
+    ordered = sorted(anchors, key=lambda anchor: minutes_since_wake(anchor.start, wake=wake))
 
     gaps: list[Gap] = []
     cursor = wake
     for anchor in ordered:
-        if minutes_since_midnight(anchor.start) > minutes_since_midnight(cursor):
+        if minutes_since_wake(anchor.start, wake=wake) > minutes_since_wake(cursor, wake=wake):
             gaps.append(Gap(start=cursor, end=anchor.start))
         cursor = anchor.end
-    if minutes_since_midnight(sleep) > minutes_since_midnight(cursor):
+    if minutes_since_wake(sleep, wake=wake) > minutes_since_wake(cursor, wake=wake):
         gaps.append(Gap(start=cursor, end=sleep))
     return tuple(gaps)
 
 
-def _find_gap_for_start(gaps: Sequence[Gap], start: time) -> Gap | None:
-    start_minutes = minutes_since_midnight(start)
+def _find_gap_for_start(gaps: Sequence[Gap], start: time, *, wake: time) -> Gap | None:
+    start_minutes = minutes_since_wake(start, wake=wake)
     for gap in gaps:
-        gap_start = minutes_since_midnight(gap.start)
-        gap_end = minutes_since_midnight(gap.end)
+        gap_start = minutes_since_wake(gap.start, wake=wake)
+        gap_end = minutes_since_wake(gap.end, wake=wake)
         if gap_start <= start_minutes < gap_end:
             return gap
     return None
@@ -222,24 +243,25 @@ def validate_flex_placement(
     gaps: Sequence[Gap],
     anchors: Sequence[Anchor],
     other_flexes: Sequence[Flex],
+    wake: time,
 ) -> bool:
     """Return True when a placed Flex fits its Gap and does not overlap."""
 
     if flex.start is None or flex.end is None:
         return False
 
-    gap = _find_gap_for_start(gaps, flex.start)
+    gap = _find_gap_for_start(gaps, flex.start, wake=wake)
     if gap is None:
         return False
 
-    start_minutes = minutes_since_midnight(flex.start)
+    start_minutes = minutes_since_wake(flex.start, wake=wake)
     end_minutes = start_minutes + _occupied_minutes(flex.duration)
-    gap_end_minutes = minutes_since_midnight(gap.end)
+    gap_end_minutes = minutes_since_wake(gap.end, wake=wake)
     if end_minutes > gap_end_minutes:
         return False
 
     for anchor in anchors:
-        anchor_start = minutes_since_midnight(anchor.start)
+        anchor_start = minutes_since_wake(anchor.start, wake=wake)
         anchor_end = anchor_start + _anchor_occupied_minutes(anchor)
         if start_minutes < anchor_end and end_minutes > anchor_start:
             return False
@@ -247,7 +269,7 @@ def validate_flex_placement(
     for other in other_flexes:
         if other.start is None or other.end is None:
             continue
-        other_start = minutes_since_midnight(other.start)
+        other_start = minutes_since_wake(other.start, wake=wake)
         other_end = other_start + _occupied_minutes(other.duration)
         if start_minutes < other_end and end_minutes > other_start:
             return False
@@ -269,24 +291,29 @@ def finalize_plan(
     """
     blockers: list[Blocker] = [DraftUnfinishedBlocker(draft=draft) for draft in drafts]
 
-    wake_minutes = _bound_minutes(bounds.wake)
-    sleep_minutes = _bound_minutes(bounds.sleep)
+    wake = parse_clock(bounds.wake)
+    sleep = parse_clock(bounds.sleep)
+
+    if wake == sleep:
+        blockers.append(DegenerateDayBoundsBlocker(bounds=bounds))
+
+    sleep_minutes = minutes_since_wake(sleep, wake=wake)
 
     ordered_anchors = tuple(
-        sorted(anchors, key=lambda anchor: minutes_since_midnight(anchor.start))
+        sorted(anchors, key=lambda anchor: minutes_since_wake(anchor.start, wake=wake))
     )
 
     for anchor in ordered_anchors:
-        start_minutes = minutes_since_midnight(anchor.start)
+        start_minutes = minutes_since_wake(anchor.start, wake=wake)
         end_minutes = start_minutes + _anchor_occupied_minutes(anchor)
-        if start_minutes < wake_minutes or end_minutes > sleep_minutes:
+        if end_minutes > sleep_minutes:
             blockers.append(AnchorOutOfBoundsBlocker(anchor=anchor))
 
     for first, second in zip(ordered_anchors, ordered_anchors[1:]):
-        first_end_minutes = minutes_since_midnight(first.start) + _anchor_occupied_minutes(
-            first
-        )
-        second_start_minutes = minutes_since_midnight(second.start)
+        first_end_minutes = minutes_since_wake(
+            first.start, wake=wake
+        ) + _anchor_occupied_minutes(first)
+        second_start_minutes = minutes_since_wake(second.start, wake=wake)
         if second_start_minutes < first_end_minutes:
             blockers.append(AnchorOverlapBlocker(first=first, second=second))
 
@@ -298,7 +325,11 @@ def finalize_plan(
             blockers.append(FlexUnplacedBlocker(flex=flex))
             continue
         if not validate_flex_placement(
-            flex, gaps=gaps, anchors=ordered_anchors, other_flexes=placed_flexes
+            flex,
+            gaps=gaps,
+            anchors=ordered_anchors,
+            other_flexes=placed_flexes,
+            wake=wake,
         ):
             blockers.append(FlexDoesNotFitBlocker(flex=flex))
             continue
@@ -308,7 +339,7 @@ def finalize_plan(
         return FinalizeResult(plan=None, blockers=tuple(blockers))
 
     ordered_flexes = tuple(
-        sorted(placed_flexes, key=lambda flex: minutes_since_midnight(flex.start))
+        sorted(placed_flexes, key=lambda flex: minutes_since_wake(flex.start, wake=wake))
     )
     return FinalizeResult(
         plan=FinalizedPlan(bounds=bounds, anchors=ordered_anchors, flexes=ordered_flexes),
@@ -335,6 +366,10 @@ def describe_blocker(blocker: Blocker) -> str:
         )
     if isinstance(blocker, FlexUnplacedBlocker):
         return f"Flex '{blocker.flex.name}' is not yet placed in a Gap."
+    if isinstance(blocker, DegenerateDayBoundsBlocker):
+        return (
+            f"Wake and sleep are both {blocker.bounds.wake}, leaving a zero-length day."
+        )
     return (
         f"Flex '{blocker.flex.name}' "
         f"({blocker.flex.start:%H:%M}\u2013{blocker.flex.end:%H:%M}) "

--- a/tomorrow/plan.py
+++ b/tomorrow/plan.py
@@ -7,7 +7,14 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from tomorrow.checklists import Checklist, load_checklist_library
 from tomorrow.defaults import DayBounds
-from tomorrow.domain import Anchor, FinalizedPlan, Flex, minutes_since_midnight, parse_clock
+from tomorrow.domain import (
+    Anchor,
+    FinalizedPlan,
+    Flex,
+    is_next_day,
+    minutes_since_wake,
+    parse_clock,
+)
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
@@ -32,6 +39,13 @@ def _format_clock(value: time) -> str:
     return value.strftime("%H:%M")
 
 
+def _clock_label(value: time, *, wake: time) -> str:
+    label = _format_clock(value)
+    if is_next_day(value, wake=wake):
+        return f"{label} +1"
+    return label
+
+
 def _format_duration(minutes: int) -> str:
     if minutes >= 60 and minutes % 60 == 0:
         hours = minutes // 60
@@ -53,6 +67,7 @@ def _prep_bundles(
     anchors: Sequence[Anchor],
     flexes: Sequence[Flex],
     checklists: Mapping[str, Checklist],
+    wake: time,
 ) -> list[dict[str, object]]:
     attached: list[tuple[Anchor | Flex, time]] = []
     for anchor in anchors:
@@ -61,7 +76,7 @@ def _prep_bundles(
     for flex in flexes:
         if flex.checklist and flex.start is not None:
             attached.append((flex, flex.start))
-    attached.sort(key=lambda entry: minutes_since_midnight(entry[1]))
+    attached.sort(key=lambda entry: minutes_since_wake(entry[1], wake=wake))
 
     bundles: list[dict[str, object]] = []
     for index, (item, _) in enumerate(attached):
@@ -90,21 +105,23 @@ def _timeline_views(
 ) -> list[dict[str, str | int]]:
     wake = parse_clock(bounds.wake)
     sleep = parse_clock(bounds.sleep)
-    total_minutes = minutes_since_midnight(sleep) - minutes_since_midnight(wake)
+    total_minutes = minutes_since_wake(sleep, wake=wake)
     total_height = 420
 
     items: list[tuple[str, Anchor | Flex]] = [
         ("anchor", anchor) for anchor in anchors
     ] + [("flex", flex) for flex in flexes if flex.start is not None]
-    items.sort(key=lambda entry: minutes_since_midnight(entry[1].start))
+    items.sort(key=lambda entry: minutes_since_wake(entry[1].start, wake=wake))
 
     views: list[dict[str, str | int]] = []
     cursor = wake
     for kind, item in items:
         start = item.start
         assert start is not None
-        if minutes_since_midnight(start) > minutes_since_midnight(cursor):
-            gap_minutes = minutes_since_midnight(start) - minutes_since_midnight(cursor)
+        if minutes_since_wake(start, wake=wake) > minutes_since_wake(cursor, wake=wake):
+            gap_minutes = minutes_since_wake(start, wake=wake) - minutes_since_wake(
+                cursor, wake=wake
+            )
             views.append(
                 {
                     "kind": "gap",
@@ -117,15 +134,17 @@ def _timeline_views(
             {
                 "kind": kind,
                 "name": item.name,
-                "start_label": _format_clock(start),
-                "end_label": _format_clock(item.end),
+                "start_label": _clock_label(start, wake=wake),
+                "end_label": _clock_label(item.end, wake=wake),
                 "min_height_px": max(52, int((duration_minutes / total_minutes) * total_height)),
             }
         )
         cursor = item.end
 
-    if minutes_since_midnight(sleep) > minutes_since_midnight(cursor):
-        gap_minutes = minutes_since_midnight(sleep) - minutes_since_midnight(cursor)
+    if minutes_since_wake(sleep, wake=wake) > minutes_since_wake(cursor, wake=wake):
+        gap_minutes = minutes_since_wake(sleep, wake=wake) - minutes_since_wake(
+            cursor, wake=wake
+        )
         views.append(
             {
                 "kind": "gap",
@@ -152,14 +171,18 @@ def render_plan(
         autoescape=select_autoescape(["html"]),
     )
     template = env.get_template("plan.html.j2")
+    wake = parse_clock(bounds.wake)
+    sleep = parse_clock(bounds.sleep)
     return template.render(
         plan_date_label=format_plan_date(plan_date),
         plan_date_key=plan_date.isoformat(),
         wake=bounds.wake,
-        sleep=bounds.sleep,
+        sleep=_clock_label(sleep, wake=wake),
         weather=weather,
         timeline=_timeline_views(bounds=bounds, anchors=anchors, flexes=flexes),
-        prep_bundles=_prep_bundles(anchors=anchors, flexes=flexes, checklists=library),
+        prep_bundles=_prep_bundles(
+            anchors=anchors, flexes=flexes, checklists=library, wake=wake
+        ),
     )
 
 

--- a/tomorrow/session.py
+++ b/tomorrow/session.py
@@ -28,7 +28,8 @@ from tomorrow.domain import (
     compute_gaps,
     describe_blocker,
     finalize_plan,
-    minutes_between,
+    is_next_day,
+    minutes_since_wake,
     parse_clock,
 )
 from tomorrow.day_templates import (
@@ -665,18 +666,27 @@ def session_view(
     undo = document.get("undo", {"past": [], "future": []})
     plan_date = date.fromisoformat(document["plan_date"])
     data_dir = repo_root / "data"
-    gaps = [
-        {
+    wake_time = parse_clock(bounds.wake)
+    gaps = []
+    for gap in compute_gaps(bounds=bounds, anchors=anchors):
+        gap_view = {
             "start": gap.start.strftime("%H:%M"),
             "end": gap.end.strftime("%H:%M"),
-            "duration_minutes": minutes_between(gap.start, gap.end),
+            "duration_minutes": minutes_since_wake(gap.end, wake=wake_time)
+            - minutes_since_wake(gap.start, wake=wake_time),
         }
-        for gap in compute_gaps(bounds=bounds, anchors=anchors)
-    ]
+        if is_next_day(gap.start, wake=wake_time):
+            gap_view["start_is_next_day"] = True
+        if is_next_day(gap.end, wake=wake_time):
+            gap_view["end_is_next_day"] = True
+        gaps.append(gap_view)
+    bounds_view = dict(document["bounds"])
+    if is_next_day(parse_clock(bounds.sleep), wake=wake_time):
+        bounds_view["sleep_is_next_day"] = True
     return {
         "plan_date": document["plan_date"],
         "plan_date_label": format_plan_date(plan_date),
-        "bounds": document["bounds"],
+        "bounds": bounds_view,
         "template_offer": document["template_offer"],
         "show_template_offer": _show_template_offer(repo_root, document),
         "drafts": [

--- a/tomorrow/static/session.html
+++ b/tomorrow/static/session.html
@@ -352,7 +352,8 @@
       return hours * 60 + minutes;
     }
 
-    function toClock(minutes) {
+    function toClock(minutesRaw) {
+      const minutes = ((minutesRaw % 1440) + 1440) % 1440;
       const hours = Math.floor(minutes / 60);
       const mins = minutes % 60;
       return String(hours).padStart(2, "0") + ":" + String(mins).padStart(2, "0");
@@ -360,6 +361,21 @@
 
     function endClock(start, durationMin) {
       return toClock(toMin(start) + Number(durationMin));
+    }
+
+    // Wake-relative offset, mirroring tomorrow.domain.minutes_since_wake:
+    // a clock time earlier than wake is "tomorrow, early morning" rather
+    // than "today, very early" (see docs/adr/0003).
+    function toWakeMin(clock, wake) {
+      return (((toMin(clock) - toMin(wake)) % 1440) + 1440) % 1440;
+    }
+
+    function isNextDay(clock, wake) {
+      return toMin(clock) < toMin(wake);
+    }
+
+    function clockLabel(clock, wake) {
+      return clock + (isNextDay(clock, wake) ? " +1" : "");
     }
 
     function fmtDur(minutes) {
@@ -423,8 +439,8 @@
     }
 
     function railRows(session) {
-      const wake = toMin(session.bounds.wake);
-      const sleep = toMin(session.bounds.sleep);
+      const wakeClock = session.bounds.wake;
+      const sleep = toWakeMin(session.bounds.sleep, wakeClock);
       const occupied = (session.anchors || []).map(item => ({
         kind: "anchor",
         id: item.id,
@@ -441,27 +457,27 @@
         durationMin: item.duration_minutes,
         end: endClock(item.start, item.duration_minutes),
         checklist: item.checklist
-      }))).sort((a, b) => toMin(a.start) - toMin(b.start));
+      }))).sort((a, b) => toWakeMin(a.start, wakeClock) - toWakeMin(b.start, wakeClock));
       const rows = [];
-      let cursor = wake;
+      let cursor = 0;
       for (const item of occupied) {
-        const start = toMin(item.start);
+        const start = toWakeMin(item.start, wakeClock);
         if (start > cursor) {
           rows.push({
             kind: "gap",
-            start: toClock(cursor),
+            start: toClock(toMin(wakeClock) + cursor),
             end: item.start,
             durationMin: start - cursor
           });
         }
         rows.push(item);
-        cursor = Math.max(cursor, toMin(item.end));
+        cursor = Math.max(cursor, toWakeMin(item.end, wakeClock));
       }
       if (sleep > cursor) {
         rows.push({
           kind: "gap",
-          start: toClock(cursor),
-          end: toClock(sleep),
+          start: toClock(toMin(wakeClock) + cursor),
+          end: session.bounds.sleep,
           durationMin: sleep - cursor
         });
       }
@@ -481,25 +497,28 @@
     }
 
     function renderRail(session) {
-      const total = Math.max(1, toMin(session.bounds.sleep) - toMin(session.bounds.wake));
+      const wakeClock = session.bounds.wake;
+      const total = Math.max(1, toWakeMin(session.bounds.sleep, wakeClock));
       document.getElementById("rail").innerHTML = railRows(session).map(row => {
+        const startLabel = clockLabel(row.start, wakeClock);
+        const endLabel = row.end ? clockLabel(row.end, wakeClock) : row.end;
         if (row.kind === "gap") {
           const armed = armedFlexId ? " armed" : "";
           const cta = armedFlexId ? "Place here" : "Place Flex";
           return '<button type="button" class="gap' + armed + '" data-kind="gap" data-start="' +
             esc(row.start) + '" data-end="' + esc(row.end) + '" style="min-height:' +
             heightPx(row.durationMin, total, 40) + 'px">' +
-            '<span class="time-tag">' + esc(row.start) + "</span>" +
+            '<span class="time-tag">' + esc(startLabel) + "</span>" +
             "<span>Gap · " + esc(fmtDur(row.durationMin)) + "</span>" +
             '<span class="cta">' + cta + "</span></button>";
         }
         const checklistLabel = checklistName(row.checklist);
         return '<button type="button" class="block ' + row.kind + '" data-kind="' + row.kind +
           '" data-id="' + esc(row.id) + '" style="min-height:' + heightPx(row.durationMin, total, 52) + 'px">' +
-          '<span class="time-tag">' + esc(row.start) + "</span>" +
+          '<span class="time-tag">' + esc(startLabel) + "</span>" +
           '<div class="block-title">' + esc(row.name) + "</div>" +
           (checklistLabel ? '<div class="block-checklist">' + esc(checklistLabel) + "</div>" : "") +
-          '<div class="block-range">' + esc(row.start) + "–" + esc(row.end) +
+          '<div class="block-range">' + esc(startLabel) + "–" + esc(endLabel) +
           " · " + esc(fmtDur(row.durationMin)) + "</div></button>";
       }).join("");
     }
@@ -569,7 +588,8 @@
       document.getElementById("weather").innerHTML = weatherBits.join(" · ");
       document.getElementById("blockers").textContent = (session.blockers || []).join(" ");
       document.getElementById("wake-cap").textContent = "↑ " + session.bounds.wake + " wake";
-      document.getElementById("sleep-cap").textContent = session.bounds.sleep + " sleep ↓";
+      document.getElementById("sleep-cap").textContent =
+        clockLabel(session.bounds.sleep, session.bounds.wake) + " sleep ↓";
       renderTemplateOffer(session);
       renderRail(session);
       renderDrafts(session);
@@ -643,7 +663,7 @@
 
     function resolveDurationMinutes(form) {
       if (form.dataset.durationMode === "end") {
-        const diff = toMin(clockValue(form.end)) - toMin(clockValue(form.start));
+        const diff = toWakeMin(clockValue(form.end), clockValue(form.start));
         if (!(diff > 0)) {
           document.getElementById("end-error").hidden = false;
           return null;


### PR DESCRIPTION
## Summary
- Day bounds, Anchors, Flex, and Gaps now compare clock times as minutes-since-wake (`(clock - wake) mod 1440`) instead of minutes-since-midnight, so a sleep time at or before wake (e.g. wake 07:00, sleep 01:00), or any Anchor's early clock time, is correctly understood as landing after midnight.
- `wake == sleep` is now blocked at finalize-time via a new `DegenerateDayBoundsBlocker`, consistent with how other bounds problems already surface.
- Past-midnight clock times get a "+1" marker wherever displayed: the in-progress Session view (`bounds.sleep_is_next_day`, per-gap `start_is_next_day`/`end_is_next_day`) and the rendered Plan.
- `session.html`'s client-side JS mirrors the same wake-relative arithmetic (`toWakeMin`, `isNextDay`) for live layout and the "+1" marker.
- Closes #34.

## Test plan
- [x] `uv run python -m pytest tests/test_domain.py tests/test_plan.py tests/test_session.py` — 131 passed
- [x] Manually verified end-to-end (Python API) with wake 07:00 / sleep 01:00: Anchor at 19:00, Flex placed at 00:15, gaps computed correctly across midnight, rendered Plan shows "01:00 +1" and "Sleep 01:00 +1"
- [ ] Manual browser verification of `session.html` live drag/edit preview (no automated JS test harness in this repo)

Note: `tests/test_cli.py`'s HTTP-server tests could not be run in this environment because port 8765 was already bound by the user's own live `tomorrow` session server — unrelated to this change; all other 131 tests pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)